### PR TITLE
NoMethodError (undefined method `collect' for nil:NilClass):

### DIFF
--- a/lib/whoops_rails_logger/exception_strategy.rb
+++ b/lib/whoops_rails_logger/exception_strategy.rb
@@ -43,7 +43,7 @@ module WhoopsRailsLogger
 
       self.add_message_builder(:create_event_group_identifier) do |message, raw_data|
         identifier = "#{message.details[:controller]}##{message.details[:action]}"
-        identifier << message.details["backtrace"].collect{|b| b.gsub(/:in.*/, "")}.join("\n")
+        identifier << message.details[:backtrace].collect{|b| b.gsub(/:in.*/, "")}.join("\n")
         message.event_group_identifier = Digest::MD5.hexdigest(identifier)
       end
     end


### PR DESCRIPTION
This gem produces a NoMethodError right out of the box:
- set up like in README
- create simple controller and method
- raise Exception, 'bogus' 

Exception: 
`NoMethodError (undefined method `collect' for nil:NilClass):
       whoops_rails_logger (0.1.15) lib/whoops_rails_logger/exception_strategy.rb:46:in `block in add_message_builders`
       whoops_logger (0.1.4) lib/whoops_logger/strategy.rb:32:in `call'`

Solution is attached in code. 
