### PR TITLE
Log raw POST with Rails exception

### DIFF
--- a/lib/whoops_rails_logger/exception_strategy.rb
+++ b/lib/whoops_rails_logger/exception_strategy.rb
@@ -30,6 +30,7 @@ module WhoopsRailsLogger
 
         details[:http_host]      = rack_env["HTTP_HOST"]        
         details[:params]         = rack_env["action_dispatch.request.parameters"]
+        details[:raw_post_data]  = rack_env["RAW_POST_DATA"]  
         details[:controller]     = details[:params][:controller] if details[:params]
         details[:action]         = details[:params][:action]     if details[:params]
         details[:query_string]   = rack_env["QUERY_STRING"]


### PR DESCRIPTION
Just a one liner which adds the raw post data to the details of the rails exception strategy. Useful when monitoring/debugging custom APIs. 
